### PR TITLE
v25.9.5

### DIFF
--- a/neurotorchmz/__init__.py
+++ b/neurotorchmz/__init__.py
@@ -2,7 +2,7 @@
 Neurotorch is a tool designed to extract regions of synaptic activity in neurons tagges with iGluSnFR, but is in general capable to find any kind of local brightness increase 
 due to synaptic activity.
 """
-__version__ = "25.9.4"
+__version__ = "25.9.5"
 __author__ = "Andreas Brilka"
 
 from .core.session import Session, Edition

--- a/neurotorchmz/plugins/pyimage_j/pyimagej.py
+++ b/neurotorchmz/plugins/pyimage_j/pyimagej.py
@@ -293,7 +293,7 @@ class ImageJHandler:
             
             if isinstance(roi, CircularSynapseROI):
                 if roi.radius is None: continue
-                roi = ImageJHandler.OvalRoi(roi.location[0]-roi.radius, roi.location[1]-roi.radius, 2*roi.radius+1, 2*roi.radius+1) # type: ignore
+                roi = ImageJHandler.OvalRoi(roi.location[1]-roi.radius, roi.location[0]-roi.radius, 2*roi.radius+1, 2*roi.radius+1) # type: ignore
                 roi.setName(name)
                 ImageJHandler.RM.addRoi(roi) # type: ignore
                 roi_count += 1

--- a/neurotorchmz/utils/synapse_detection_integration.py
+++ b/neurotorchmz/utils/synapse_detection_integration.py
@@ -242,7 +242,7 @@ class LocalMax_Integration(LocalMax, IDetectionAlgorithmIntegration):
         self.setting_polygonal_ROIS.var.int_var.trace_add("write", lambda _1,_2,_3:self.setting_radius.set_visibility(not self.setting_polygonal_ROIS.get()))
         self.setting_polygonal_ROIS.var.set_callback(lambda: self.setting_radius.set_visibility(not self.setting_polygonal_ROIS.get()))
 
-        self.setting_radius = GridSetting(self.optionsFrame, row=11, text="Radius", unit="px", default=6, min_=1, max_=1000, scale_min=-1, scale_max=30, tooltip=resources.get_string("algorithms/localMax/params/radius"))
+        self.setting_radius = GridSetting(self.optionsFrame, row=11, text="Radius", unit="px", default=6, min_=1, max_=1000, scale_min=1, scale_max=30, tooltip=resources.get_string("algorithms/localMax/params/radius"))
         self.setting_radius.set_visibility(not self.setting_polygonal_ROIS.get())
         self.setting_lowerTh = GridSetting(self.optionsFrame, row=12, text="Lower threshold", unit="", default=50, min_=0, max_=2**15-1, scale_min=1, scale_max=400, tooltip=resources.get_string("algorithms/localMax/params/lowerThreshold"))
         self.setting_upperTh = GridSetting(self.optionsFrame, row=13, text="Upper threshold", unit="", default=70, min_=0, max_=2**15-1, scale_min=1, scale_max=400, tooltip=resources.get_string("algorithms/localMax/params/upperThreshold"))


### PR DESCRIPTION
fixed:
- inverted ROIs when exporting Circular ROIs to Fiji/ImageJ
- Radius Slider in LocalMax_Integration can go below 1 px --> invalid